### PR TITLE
reorganize imports

### DIFF
--- a/src/actinia_statistic_plugin/ephemeral_raster_area_stats.py
+++ b/src/actinia_statistic_plugin/ephemeral_raster_area_stats.py
@@ -13,7 +13,7 @@ import tempfile
 from copy import deepcopy
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from .response_models import CategoricalStatisticsResultModel, RasterAreaStatsResponseModel
 from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
 

--- a/src/actinia_statistic_plugin/ephemeral_raster_area_stats_univar.py
+++ b/src/actinia_statistic_plugin/ephemeral_raster_area_stats_univar.py
@@ -13,7 +13,7 @@ from actinia_core.resources.resource_base import ResourceBase
 from actinia_core.resources.common.redis_interface import enqueue_job
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from .response_models import AreaUnivarResultModel, RasterAreaUnivarStatsResponseModel
 from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
 

--- a/src/actinia_statistic_plugin/ephemeral_strds_area_stats.py
+++ b/src/actinia_statistic_plugin/ephemeral_strds_area_stats.py
@@ -15,7 +15,7 @@ from actinia_core.resources.common.redis_interface import enqueue_job
 from actinia_core.resources.common.exceptions import AsyncProcessError
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from .response_models import CategoricalStatisticsResultModel, RasterAreaStatsResponseModel
 from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
 

--- a/src/actinia_statistic_plugin/ephemeral_strds_area_stats_univar.py
+++ b/src/actinia_statistic_plugin/ephemeral_strds_area_stats_univar.py
@@ -15,7 +15,7 @@ from actinia_core.resources.common.redis_interface import enqueue_job
 from actinia_core.resources.common.exceptions import AsyncProcessError
 from flask_restful_swagger_2 import swagger
 from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.logging_interface import log_api_call
+from actinia_core.resources.common.api_logger import log_api_call
 from .response_models import AreaUnivarResultModel, RasterAreaUnivarStatsResponseModel
 from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
 


### PR DESCRIPTION
This PR changes the source of 4 import statements from `logging_interface` to `api_logger`. As `logging_interface` did import itself from `api_logger`, this won't change functional code but will be needed for https://github.com/mundialis/actinia_core/pull/47.

Also related to https://github.com/mundialis/actinia_satellite_plugin/pull/6