### PR TITLE
Move actinia_core imports

### DIFF
--- a/src/actinia_statistic_plugin/ephemeral_raster_area_stats.py
+++ b/src/actinia_statistic_plugin/ephemeral_raster_area_stats.py
@@ -4,18 +4,18 @@ Compute areal categorical statistics on a raster map layer based on an input pol
 """
 
 from flask import jsonify, make_response
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
 from flask.json import dumps
 import pickle
 import tempfile
 from copy import deepcopy
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
 from .response_models import CategoricalStatisticsResultModel, RasterAreaStatsResponseModel
-from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
+from actinia_core.models.response_models import ProcessingErrorResponseModel
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/src/actinia_statistic_plugin/ephemeral_raster_area_stats_univar.py
+++ b/src/actinia_statistic_plugin/ephemeral_raster_area_stats_univar.py
@@ -8,14 +8,14 @@ import pickle
 import tempfile
 from copy import deepcopy
 from flask import jsonify, make_response
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
 from .response_models import AreaUnivarResultModel, RasterAreaUnivarStatsResponseModel
-from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
+from actinia_core.models.response_models import ProcessingErrorResponseModel
 
 __license__ = "GPLv3"
 __author__     = "Sören Gebbert"

--- a/src/actinia_statistic_plugin/ephemeral_strds_area_stats.py
+++ b/src/actinia_statistic_plugin/ephemeral_strds_area_stats.py
@@ -9,15 +9,15 @@ from datetime import datetime
 from copy import deepcopy
 from flask import jsonify, make_response
 from flask.json import dumps
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.exceptions import AsyncProcessError
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.exceptions import AsyncProcessError
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
 from .response_models import CategoricalStatisticsResultModel, RasterAreaStatsResponseModel
-from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
+from actinia_core.models.response_models import ProcessingErrorResponseModel
 
 
 __license__ = "GPLv3"

--- a/src/actinia_statistic_plugin/ephemeral_strds_area_stats_univar.py
+++ b/src/actinia_statistic_plugin/ephemeral_strds_area_stats_univar.py
@@ -9,15 +9,15 @@ from datetime import datetime
 from flask import jsonify, make_response
 from copy import deepcopy
 from flask.json import dumps
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.exceptions import AsyncProcessError
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.exceptions import AsyncProcessError
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.common.app import auth
-from actinia_core.resources.common.api_logger import log_api_call
+from actinia_core.core.common.app import auth
+from actinia_core.core.common.api_logger import log_api_call
 from .response_models import AreaUnivarResultModel, RasterAreaUnivarStatsResponseModel
-from actinia_core.resources.common.response_models import ProcessingErrorResponseModel
+from actinia_core.models.response_models import ProcessingErrorResponseModel
 
 
 __license__ = "GPLv3"

--- a/src/actinia_statistic_plugin/response_models.py
+++ b/src/actinia_statistic_plugin/response_models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask_restful_swagger_2 import Schema
 from copy import deepcopy
-from actinia_core.resources.common.response_models import ProcessingResponseModel
+from actinia_core.models.response_models import ProcessingResponseModel
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"

--- a/src/actinia_statistic_plugin/strds_sampling.py
+++ b/src/actinia_statistic_plugin/strds_sampling.py
@@ -8,11 +8,11 @@ import tempfile
 from flask import jsonify, make_response
 from copy import deepcopy
 from flask_restful_swagger_2 import swagger, Schema
-from actinia_core.resources.common.response_models import ProcessingResponseModel, ProcessingErrorResponseModel
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
-from actinia_core.resources.common.exceptions import AsyncProcessError
+from actinia_core.models.response_models import ProcessingResponseModel, ProcessingErrorResponseModel
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
+from actinia_core.core.common.exceptions import AsyncProcessError
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"

--- a/src/actinia_statistic_plugin/strds_sampling_geojson.py
+++ b/src/actinia_statistic_plugin/strds_sampling_geojson.py
@@ -9,10 +9,10 @@ from flask import jsonify, make_response
 from flask.json import dumps as json_dumps
 from copy import deepcopy
 from flask_restful_swagger_2 import swagger
-from actinia_core.resources.common.response_models import ProcessingResponseModel, ProcessingErrorResponseModel
-from actinia_core.resources.ephemeral_processing import EphemeralProcessing
-from actinia_core.resources.resource_base import ResourceBase
-from actinia_core.resources.common.redis_interface import enqueue_job
+from actinia_core.models.response_models import ProcessingResponseModel, ProcessingErrorResponseModel
+from actinia_core.rest.ephemeral_processing import EphemeralProcessing
+from actinia_core.rest.resource_base import ResourceBase
+from actinia_core.core.common.redis_interface import enqueue_job
 
 __license__ = "GPLv3"
 __author__ = "Sören Gebbert"

--- a/tests/test_resource_base.py
+++ b/tests/test_resource_base.py
@@ -5,8 +5,8 @@ import signal
 import time
 from flask_restful import Api
 from actinia_core.testsuite import ActiniaTestCaseBase, URL_PREFIX
-from actinia_core.resources.common.config import global_config
-from actinia_core.resources.common.app import flask_app, flask_api
+from actinia_core.core.common.config import global_config
+from actinia_core.core.common.app import flask_app, flask_api
 from actinia_statistic_plugin.endpoints import create_endpoints
 from actinia_core.endpoints import create_endpoints as create_actinia_endpoints
 


### PR DESCRIPTION
As the modules follow a new folder structure in actinia_core, the imports needed to be adjusted.
See mundialis/actinia_core#221 and mundialis/actinia-module-plugin#8