### PR TITLE
raster_layers endpoint: fix missing endpoint name

### DIFF
--- a/src/actinia_statistic_plugin/endpoints.py
+++ b/src/actinia_statistic_plugin/endpoints.py
@@ -31,8 +31,6 @@ from .raster_sampling import (
     AsyncEphemeralRasterSamplingResource,
     SyncEphemeralRasterSamplingResource,
 )
-
-
 from .vector_sampling import (
     AsyncEphemeralVectorSamplingResource,
     SyncEphemeralVectorSamplingResource,
@@ -59,6 +57,7 @@ def create_endpoints(flask_api):
         "<string:strds_name>/timestamp/"
         "<string:timestamp>/area_stats_univar_sync",
     )
+
     flask_api.add_resource(
         AsyncEphemeralSTRDSAreaStatsResource,
         "/locations/<string:location_name>/mapsets/"
@@ -84,6 +83,7 @@ def create_endpoints(flask_api):
         "<string:mapset_name>/raster_layers/"
         "<string:raster_name>/area_stats_sync",
     )
+
     flask_api.add_resource(
         AsyncEphemeralRasterAreaStatsUnivarResource,
         "/locations/<string:location_name>/mapsets/"
@@ -111,6 +111,7 @@ def create_endpoints(flask_api):
         "<string:mapset_name>/strds/<string:strds_name>"
         "/sampling_sync",
     )
+
     flask_api.add_resource(
         AsyncEphemeralSTRDSSamplingGeoJSONResource,
         "/locations/<string:location_name>/mapsets/"
@@ -133,8 +134,10 @@ def create_endpoints(flask_api):
     flask_api.add_resource(
         SyncEphemeralRasterSamplingResource,
         "/locations/<string:location_name>/mapsets/"
-        "<string:mapset_name>/raster_layers/<string:raster_name>",
+        "<string:mapset_name>/raster_layers/<string:raster_name>"
+        "/sampling_sync",
     )
+
     flask_api.add_resource(
         AsyncEphemeralVectorSamplingResource,
         "/locations/<string:location_name>/mapsets/"


### PR DESCRIPTION
Fixes missing
`/locations/{location_name}/mapsets/{mapset_name}/raster_layers/{raster_name}/sampling_sync`
in list of endpoints.