### PR TITLE
Remove pprint() calls from test scripts

### DIFF
--- a/tests/test_raster_area_stats.py
+++ b/tests/test_raster_area_stats.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 import time
-from pprint import pprint
 from flask.json import loads as json_load
 from flask.json import dumps as json_dump
 
@@ -68,7 +67,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -91,7 +89,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -113,7 +110,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -132,7 +128,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,

--- a/tests/test_raster_area_stats_univar.py
+++ b/tests/test_raster_area_stats_univar.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import unittest
-from pprint import pprint
 from flask.json import loads as json_load
 from flask.json import dumps as json_dump
 
@@ -79,7 +78,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -107,7 +105,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -133,7 +130,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/XML",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -153,7 +149,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -173,7 +168,6 @@ class RasterAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,

--- a/tests/test_raster_area_stats_univar.py
+++ b/tests/test_raster_area_stats_univar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
-from flask.json import loads as json_load
+# from flask.json import loads as json_load
 from flask.json import dumps as json_dump
 
 try:

--- a/tests/test_raster_sample.py
+++ b/tests/test_raster_sample.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 import time
-from pprint import pprint
 from flask.json import loads as json_load
 from flask.json import dumps as json_dump
 
@@ -57,7 +56,6 @@ class RasterTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -115,7 +113,6 @@ class RasterTestCase(ActiniaResourceTestCaseBase):
                                        ["p2", "635676.0", "226371.0"]]}),
             content_type="application/json")
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code, 200, "HTML status code is wrong %i"
             % rv.status_code)
@@ -145,7 +142,6 @@ class RasterTestCase(ActiniaResourceTestCaseBase):
            data=json_dump(JSON),
            content_type="application/json")
 
-       pprint(json_load(rv.data))
        self.assertEqual(
            rv.status_code, 200, "HTML status code is wrong %i"
            % rv.status_code)

--- a/tests/test_strds_area_stats.py
+++ b/tests/test_strds_area_stats.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 # import time
-# from pprint import pprint
 # from flask.json import loads as json_load
 # from flask.json import dumps as json_dump
 #
@@ -58,7 +57,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -83,7 +81,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -109,7 +106,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -133,7 +129,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -154,7 +149,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/XML",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -175,7 +169,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -196,7 +189,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -217,7 +209,6 @@ class STRDSAreaStatsTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,

--- a/tests/test_strds_area_stats_univar.py
+++ b/tests/test_strds_area_stats_univar.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 # import time
-# from pprint import pprint
 # from flask.json import loads as json_load
 # from flask.json import dumps as json_dump
 
@@ -61,7 +60,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -88,7 +86,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -113,7 +110,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -138,7 +134,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="text/XML",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -159,7 +154,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -180,7 +174,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,
@@ -201,7 +194,6 @@ class STRDSAreaStatsUnivarTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             400,

--- a/tests/test_strds_sample.py
+++ b/tests/test_strds_sample.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 # import time
-# from pprint import pprint
 # from flask.json import loads as json_load
 # from flask.json import dumps as json_dump
 #
@@ -78,7 +77,6 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -138,7 +136,6 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -168,7 +165,6 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -205,7 +201,6 @@ class STRDSTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,

--- a/tests/test_vector_sample.py
+++ b/tests/test_vector_sample.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 # import time
-# from pprint import pprint
 # from flask.json import loads as json_load
 # from flask.json import dumps as json_dump
 #
@@ -39,7 +38,6 @@ class VectorTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,
@@ -100,7 +98,6 @@ class VectorTestCase(ActiniaResourceTestCaseBase):
             content_type="application/json",
         )
 
-        pprint(json_load(rv.data))
         self.assertEqual(
             rv.status_code,
             200,


### PR DESCRIPTION
PR removes debug left-over `pprint()` in following scripts:
```
tests/test_strds_area_stats.py
tests/test_strds_sample.py
tests/test_vector_sample.py
tests/test_raster_sample.py
tests/test_strds_area_stats_univar.py
tests/test_raster_area_stats_univar.py
tests/test_raster_area_stats.py
```

Solves #10 