### PR TITLE
tests_with_kvdb.sh: fix comparison in shell

### DIFF
--- a/tests_with_kvdb.sh
+++ b/tests_with_kvdb.sh
@@ -30,11 +30,11 @@ valkey-cli ping
 echo "${ACTINIA_CUSTOM_TEST_CFG}"
 echo "${DEFAULT_CONFIG_PATH}"
 
-if [ "$1" == "dev" ]
+if [ "$1" = "dev" ]
 then
   echo "Executing only 'dev' tests ..."
   pytest -m "dev"
-elif [ "$1" == "integrationtest" ]
+elif [ "$1" = "integrationtest" ]
 then
   pytest -m "integrationtest"
 else


### PR DESCRIPTION
Comparison in shell is done with single `=` to be portable.